### PR TITLE
Remove endless loop when special characters are in filename

### DIFF
--- a/get_directory_sizes.py
+++ b/get_directory_sizes.py
@@ -99,7 +99,7 @@ def get_folder_sizes(
                 try:
                     if verbose:
                         logging.info('Getting info for %s', path)
-                    resp = session.get('%s%s' % (storage_api_url, path), timeout=30)
+                    resp = session.get('%s%s' % (storage_api_url, requests.compat.quote(path)), timeout=30)
                     if resp.status_code == 404:
                         out_queue.put((None, None, None))
                         continue


### PR DESCRIPTION
Artifactory seems to require a encoded URL when a path
contains special characters such as '%'. If such character is in the
path or filename, Artifactory will return a HTTP 400 error and the script will
endlessly requeue the element.

This commit applies URL encoding before requeueing the path if a HTTP 400
error is raised.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reversefold/artifactory-disk-usage/4)
<!-- Reviewable:end -->
